### PR TITLE
Allow configuring the full frontend URL

### DIFF
--- a/src/ControllerProvider/index.js
+++ b/src/ControllerProvider/index.js
@@ -28,7 +28,8 @@ const IPLookUp = 'http://ip-api.com/json/'
 
 // If dev mode, use proxy
 // Otherwise assume you are running on the Controller
-const getUrl = (path) => controllerJson.dev ? `/api/controllerApi${path}` : `${window.location.protocol}//${[window.location.hostname, controllerJson.port].join(':')}${path}`
+const getBaseUrl = () => controllerJson.url || `${window.location.protocol}//${[window.location.hostname, controllerJson.port].join(':')}`;
+const getUrl = (path) => controllerJson.dev ? `/api/controllerApi${path}` : `${getBaseUrl()}${path}`;
 const getHeaders = (headers) => controllerJson.dev
   ? ({
     ...headers,


### PR DESCRIPTION
This allows to bypass the guessing of the frontend URL by providing complete URL through configuration.